### PR TITLE
feat: bump avatax version to remove faraday_middleware-parse_oj

### DIFF
--- a/lib/spree_avatax_official/version.rb
+++ b/lib/spree_avatax_official/version.rb
@@ -1,5 +1,5 @@
 module SpreeAvataxOfficial
-  VERSION = '1.8.0'.freeze
+  VERSION = '1.8.1'.freeze
 
   module_function
 

--- a/spree_avatax_official.gemspec
+++ b/spree_avatax_official.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'avatax', '>= 19.3'
+  s.add_dependency 'avatax', '>= 20.7.0'
 
   spree_version = '>= 2.1.0'
 


### PR DESCRIPTION
## Problem
```sh
Could not find compatible versions

Because every version of gibbon depends on faraday >= 1.0
  and faraday_middleware-parse_oj >= 0.3.1 depends on faraday ~> 0.9,
  every version of gibbon is incompatible with faraday_middleware-parse_oj >= 0.3.1.
And because avatax >= 17.7.3, < 20.7.0 depends on faraday_middleware-parse_oj ~> 0.3.2
  and every version of spree_avatax_official depends on avatax ~> 19.3,
  every version of gibbon is incompatible with spree_avatax_official >= 0.
So, because Gemfile depends on gibbon >= 0
  and Gemfile depends on spree_avatax_official >= 0,
  version solving has failed.
```
[Solution](https://github.com/avadev/AvaTax-REST-V2-Ruby-SDK/blob/20.7.0/avatax.gemspec)

## Testing Methods
1. `gem build gem build spree_avatax_official` creates a 1.8.1 gem
1. `gem install spree_avatax_official-1.8.1.gem --no-document --explain`
Will install dependencies on your system, in dry run mode 